### PR TITLE
Add shebangs to examples

### DIFF
--- a/examples/mail.rb
+++ b/examples/mail.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+
 require 'tins'
 require 'net/smtp'
 require 'time'

--- a/examples/null_pattern.rb
+++ b/examples/null_pattern.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+
 require 'tins'
 $:.unshift 'examples'
 

--- a/examples/turing.rb
+++ b/examples/turing.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+
 require 'term/ansicolor'
 require 'tins'
 


### PR DESCRIPTION
Some examples had executable bit set, but no shebang.
This is a strange configuration
and led Fedora buildsystem to issue a warning.
Fixed by adding the missing shebangs.