### PR TITLE
simplyify lru_cache to not need NOT_EXIST

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changes
 
+## UNRELEASED
+- Simplified implementation of LRUCache.
+
 ## 2025-12-20 v1.51.0
 
 - Added `readline` as a runtime dependency in both `Rakefile` and

--- a/lib/tins/lru_cache.rb
+++ b/lib/tins/lru_cache.rb
@@ -13,7 +13,7 @@ module Tins
     def initialize(capacity)
       @capacity = Integer(capacity)
       @capacity >= 1 or
-        raise ArgumentError, "capacity should be >= 1, was #@capacity"
+        raise ArgumentError, "capacity should be >= 1, was #{@capacity}"
       @data     = {} # Least-recently used will always be the first element
     end
 

--- a/lib/tins/lru_cache.rb
+++ b/lib/tins/lru_cache.rb
@@ -3,14 +3,9 @@ module Tins
   #
   # This cache maintains a fixed-size collection of key-value pairs,
   # automatically removing the least recently accessed item when the capacity
-  # is exceeded.
+  # is exceeded. Both read and write are considered access.
   class LRUCache
     include Enumerable
-
-    # Our "nil" value if it wasn' set by clients
-    NOT_EXIST = Object.new.freeze
-
-    private_constant :NOT_EXIST
 
     # Initializes a new LRU cache with the specified capacity.
     #
@@ -19,7 +14,7 @@ module Tins
       @capacity = Integer(capacity)
       @capacity >= 1 or
         raise ArgumentError, "capacity should be >= 1, was #@capacity"
-      @data     = {}
+      @data     = {} # Least-recently used will always be the first element
     end
 
     # Returns the maximum capacity of the cache.
@@ -35,11 +30,8 @@ module Tins
     # @param key [Object] the key to look up
     # @return [Object, nil] the value for the key or nil if not found
     def [](key)
-      case value = @data.delete(key) { NOT_EXIST }
-      when NOT_EXIST
-        nil
-      else
-        @data[key] = value
+      if @data.has_key?(key)
+        @data[key] = @data.delete(key)
       end
     end
 
@@ -56,7 +48,7 @@ module Tins
       @data.delete(key)
       @data[key] = value
       if @data.size > @capacity
-        @data.delete(@data.keys.first)
+        @data.shift
       end
       value
     end

--- a/tests/lru_cache_test.rb
+++ b/tests/lru_cache_test.rb
@@ -7,9 +7,10 @@ module Tins
     end
 
     def test_too_low_capacity
-      assert_raise ArgumentError do
+      ex = assert_raise ArgumentError do
         LRUCache.new(0)
       end
+      assert_equal 'capacity should be >= 1, was 0', ex.message
     end
 
     def test_wrong_capacity_type


### PR DESCRIPTION
I noticed that the `LRUCache` had unnecessary complexity with `NOT_EXIST = Object.new.freeze`.

Changes in this PR:

1. Simplifies the implementation to remove the `NOT_EXIST` constant from the implementation.
2. Simplifies the implementation to use `Hash#shift` instead of `Hash#delete`. This should be significantly faster.
3. Adds a test of the `ArgumentError` message.
4. Switches string interpolation from `#@capacity` to `#{@capacity}` since the latter is now the norm.